### PR TITLE
mkdirSync wasn't actually synchronous

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1,109 +1,109 @@
-var fs = require('fs');
+(function () {
+  'use strict';
 
-/**
-* Export everything already available through fs.
-*/
-for (var fun in fs) {
-  exports[fun] = fs[fun];
-}
-
-/**
-* Offers functionality similar to mkdir -p
-*
-* Asynchronous operation. No arguments other than a possible exception
-* are given to the completion callback.
-*/
-function mkdir_p (path, mode, callback, position) {
-  mode = mode || process.umask();
-  position = position || 0;
-  parts = require('path').normalize(path).split('/');
-
-  if (position >= parts.length) {
-    return callback();
-  }
-
-  var directory = parts.slice(0, position + 1).join('/') || '/';
-  fs.stat(directory, function(err) {    
-    if (err === null) {
-      mkdir_p(path, mode, callback, position + 1);
-    } else {
-      fs.mkdir(directory, mode, function (err) {
-        if (err && err.errno != 17) {
-		  return callback(err);
-        } else {
-          mkdir_p(path, mode, callback, position + 1);
-        }
-      });
-    }
-  });
-}
-
-function mkdirSync_p(path, mode, position) {
-  mode = mode || process.umask();
-  position = position || 0;
-  parts = require('path').normalize(path).split('/');
-
-  if (position >= parts.length) {
-    return true;
-  }
-
-  var directory = parts.slice(0, position + 1).join('/') || '/';
-  try {
-    fs.statSync(directory);
-    mkdirSync_p(path, mode, position + 1);
-  } catch (e) {
-    try {
-      fs.mkdirSync(directory, mode);
-    } catch (e) {
-      if (e.errno != 17) {
-        throw err;
-      }
-      mkdirSync_p(path, mode, position + 1);
-    }
-  }
-}
-
-/**
-* Polymorphic approach to fs.mkdir()
-*
-* If the third parameter is boolean and true assume that
-* caller wants recursive operation.
-*/
-exports.mkdir = function (path, mode, recursive, callback) {
-  if (typeof(recursive) != 'boolean') {
-    callback = recursive;
-    recursive = false;
-  }
-
-  if (typeof callback !== 'function') {
-    callback = function () {};
-  }
-
-  if (!recursive) {
-    fs.mkdir(path, mode, callback);
-  } else {
-    mkdir_p(path, mode, callback);
-  }
-}
-
-/**
-* Polymorphic approach to fs.mkdirSync()
-*
-* If the third parameter is boolean and true assume that
-* caller wants recursive operation.
-*/
-exports.mkdirSync = function (path, mode, recursive) {
-  if ('boolean' != typeof(recursive)) {
-    recursive = false;
-  }
-
-  if (!recursive) {
-    fs.mkdirSync(path, mode);
-  } else {
-    mkdirSync_p(path, mode);
-  }
-}
-
-exports.watchDir = function (path) {
+  var fs = require('fs'),
+      mkdirOrig = fs.mkdir,
+      mkdirSyncOrig = fs.mkdirSync;
   
-}
+  /**
+  * Offers functionality similar to mkdir -p
+  *
+  * Asynchronous operation. No arguments other than a possible exception
+  * are given to the completion callback.
+  */
+  function mkdir_p (path, mode, callback, position) {
+    var parts = require('path').normalize(path).split('/');
+
+    mode = mode || process.umask();
+    position = position || 0;
+  
+    if (position >= parts.length) {
+      return callback();
+    }
+  
+    var directory = parts.slice(0, position + 1).join('/') || '/';
+    fs.stat(directory, function(err) {    
+      if (err === null) {
+        mkdir_p(path, mode, callback, position + 1);
+      } else {
+        mkdirOrig(directory, mode, function (err) {
+          if (err && err.errno != 17) {
+            return callback(err);
+          } else {
+            mkdir_p(path, mode, callback, position + 1);
+          }
+        });
+      }
+    });
+  }
+  
+  function mkdirSync_p(path, mode, position) {
+    var parts = require('path').normalize(path).split('/');
+
+    mode = mode || process.umask();
+    position = position || 0;
+  
+    if (position >= parts.length) {
+      return true;
+    }
+  
+    var directory = parts.slice(0, position + 1).join('/') || '/';
+    try {
+      fs.statSync(directory);
+      mkdirSync_p(path, mode, position + 1);
+    } catch (e) {
+      try {
+        mkdirSyncOrig(directory, mode);
+        mkdirSync_p(path, mode, position + 1);
+      } catch (e) {
+        if (e.errno != 17) {
+          throw err;
+        }
+        mkdirSync_p(path, mode, position + 1);
+      }
+    }
+  }
+  
+  /**
+  * Polymorphic approach to fs.mkdir()
+  *
+  * If the third parameter is boolean and true assume that
+  * caller wants recursive operation.
+  */
+  fs.mkdir = function (path, mode, recursive, callback) {
+    if (typeof recursive !== 'boolean') {
+      callback = recursive;
+      recursive = false;
+    }
+  
+    if (typeof callback !== 'function') {
+      callback = function () {};
+    }
+  
+    if (!recursive) {
+      mkdirOrig(path, mode, callback);
+    } else {
+      mkdir_p(path, mode, callback);
+    }
+  }
+  
+  /**
+  * Polymorphic approach to fs.mkdirSync()
+  *
+  * If the third parameter is boolean and true assume that
+  * caller wants recursive operation.
+  */
+  fs.mkdirSync = function (path, mode, recursive) {
+    if (typeof recursive !== 'boolean') {
+      recursive = false;
+    }
+  
+    if (!recursive) {
+      mkdirSyncOrig(path, mode);
+    } else {
+      mkdirSync_p(path, mode);
+    }
+  }
+
+  module.exports = fs;
+}());


### PR DESCRIPTION
I made mkdirSync actually be synchronous, as well as some other changes.

The biggest change besides that is in the second commit, where I overwrite fs.mkdir and fs.mkdirSync. This means that all other calls to fs.mkdir will be running your code. I'm not 100% sure if this is the best idea, but it makes it simpler (and you can now require it with just require('node-fs')).
