### PR TITLE
Fix for uncaught: ReferenceError: err is not defined

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -57,7 +57,7 @@
         mkdirSync_p(path, mode, position + 1);
       } catch (e) {
         if (e.errno != 17) {
-          throw err;
+          throw e;
         }
         mkdirSync_p(path, mode, position + 1);
       }


### PR DESCRIPTION
Correcting a misnamed variable on line 60 - "err" which should be called "e"
