### PR TITLE
Update for compatibility with Windows' version of node.js

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -3,7 +3,8 @@
 
   var fs = require('fs'),
       mkdirOrig = fs.mkdir,
-      mkdirSyncOrig = fs.mkdirSync;
+      mkdirSyncOrig = fs.mkdirSync,
+      osSep = process.platform === 'win32' ? '\\' : '/';
   
   /**
   * Offers functionality similar to mkdir -p
@@ -12,7 +13,7 @@
   * are given to the completion callback.
   */
   function mkdir_p (path, mode, callback, position) {
-    var parts = require('path').normalize(path).split('/');
+    var parts = require('path').normalize(path).split(osSep);
 
     mode = mode || process.umask();
     position = position || 0;
@@ -21,7 +22,7 @@
       return callback();
     }
   
-    var directory = parts.slice(0, position + 1).join('/') || '/';
+    var directory = parts.slice(0, position + 1).join(osSep) || osSep;
     fs.stat(directory, function(err) {    
       if (err === null) {
         mkdir_p(path, mode, callback, position + 1);
@@ -38,7 +39,7 @@
   }
   
   function mkdirSync_p(path, mode, position) {
-    var parts = require('path').normalize(path).split('/');
+    var parts = require('path').normalize(path).split(osSep);
 
     mode = mode || process.umask();
     position = position || 0;
@@ -47,7 +48,7 @@
       return true;
     }
   
-    var directory = parts.slice(0, position + 1).join('/') || '/';
+    var directory = parts.slice(0, position + 1).join(osSep) || osSep;
     try {
       fs.statSync(directory);
       mkdirSync_p(path, mode, position + 1);


### PR DESCRIPTION
There is a small bug with the Windows version of Node.js, as stated by the documentation http://nodejs.org/docs/v0.3.7/api/path.html « On windows backslashes are used. ». So the function must use a system's dependent separator for the splits and joins.
