### PR TITLE
Remove os line from package.json so that the package can be used on windows...

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "url": "git://github.com/bpedro/node-fs.git"
   },
 
+  "os": [ "linux", "darwin", "freebsd", "win32" ],
+
   "devDependencies": {
     "expresso": "*"
   },


### PR DESCRIPTION
I've tested this a bit on windows, and it seems to work.  I don't know why the os is limited in package.json, given that there seems to be win32-specific code in the module itself.
