### PR TITLE
fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,6 @@
     "url": "git://github.com/bpedro/node-fs.git"
   },
 
-  "os": [ "linux", "darwin", "freebsd", "win32" ],
-
   "devDependencies": {
     "expresso": "*"
   },


### PR DESCRIPTION
It currently has an "os" directive, which is rather silly. It breaks it on SmartOS.
