### PR TITLE
Added sunOS to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git://github.com/bpedro/node-fs.git"
   },
 
-  "os": [ "linux", "darwin", "freebsd", "win32", "smartos" ],
+  "os": [ "linux", "darwin", "freebsd", "win32", "smartos", "sunos" ],
 
   "devDependencies": {
     "expresso": "*"


### PR DESCRIPTION
I wanted to use the lib on nodejitsu.com, it failed on install because they use sunOS. I installed only the module and ran the test. They all pass. 
