### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,5 @@
     "node": ">=0.1.97"
   },
 
-  "licenses": [{
-    "type" : "MIT",
-    "url" : "https://github.com/bpedro/node-fs/raw/master/LICENSE"
-  }]
+  "license": "MIT"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/
